### PR TITLE
Add network name (Display Network Name as in Old Website)

### DIFF
--- a/src/components/NavBar/NetworkName.tsx
+++ b/src/components/NavBar/NetworkName.tsx
@@ -1,0 +1,56 @@
+import { useWeb3React } from '@web3-react/core';
+import { useRef } from 'react';
+import styled from 'styled-components';
+
+import { getChainInfo } from 'constants/chainInfo';
+import useSyncChainQuery from 'hooks/useSyncChainQuery';
+
+const ChainSelectorRow = styled.div`
+  width: 162px;
+  height: 38px;
+  flex-shrink: 0;
+  margin-right: 16px;
+
+  border-radius: 8px;
+  background: var(--Jedi-Navy-Blue, #141451);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  // text content
+  color: var(--Jedi-White, #FFF);
+  text-align: center;
+  font-feature-settings: 'clig' off, 'liga' off;
+  font-family: Avenir LT Std;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 20px; /* 125% */ 
+`;
+
+export const NetworkName = () => {
+  const { chainId, account } = useWeb3React();
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const info = getChainInfo(chainId);
+
+  useSyncChainQuery();
+
+  if (!account || !chainId) {
+    return null;
+  }
+
+  const isSupported = !!info;
+
+  return (
+    <ChainSelectorRow>
+      {!isSupported ? (
+        'Unsupported Network'
+      ) : (
+        info.label
+      )}
+    </ChainSelectorRow>
+  );
+};

--- a/src/components/NavBar/NetworkName.tsx
+++ b/src/components/NavBar/NetworkName.tsx
@@ -9,17 +9,16 @@ const ChainSelectorRow = styled.div`
   width: 162px;
   height: 38px;
   flex-shrink: 0;
-  margin-right: 16px;
 
   border-radius: 8px;
-  background: var(--Jedi-Navy-Blue, #141451);
+  background:  ${({ theme }) => theme.jediNavyBlue};;
 
   display: flex;
   align-items: center;
   justify-content: center;
 
   // text content
-  color: var(--Jedi-White, #FFF);
+  color:  ${({ theme }) => theme.jediWhite};;
   text-align: center;
   font-feature-settings: 'clig' off, 'liga' off;
   font-family: Avenir LT Std;
@@ -31,8 +30,6 @@ const ChainSelectorRow = styled.div`
 
 export const NetworkName = () => {
   const { chainId, account } = useWeb3React();
-
-  const ref = useRef<HTMLDivElement>(null);
 
   const info = getChainInfo(chainId);
 

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -9,7 +9,8 @@ import { useIsPoolsPage } from 'hooks/useIsPoolsPage';
 import { Row } from 'nft/components/Flex';
 import Logo from 'assets/jedi/logo.png';
 import MobileLogo from 'assets/jedi/squareLogo.png';
-import { Nav, LogoContainer, MobileLogoContainer, MenuContainer, StatusContainer, MenuItem, ActiveMenuItem, ExternalMenuItem } from './styled';
+import { Nav, LogoContainer, NetworkNameContainer, MenuContainer, StatusContainer, MenuItem, ActiveMenuItem, ExternalMenuItem } from './styled';
+import { NetworkName } from './NetworkName';
 
 const MenuItemLink = ({ to, dataTestId, id, isActive, children }) => {
   const Component = isActive ? ActiveMenuItem : MenuItem;
@@ -74,7 +75,10 @@ const Navbar = () => {
       </MenuContainer>
 
       <StatusContainer>
-        <Row gap="12">
+        <Row gap="16">
+          <NetworkNameContainer>
+            <NetworkName />
+          </NetworkNameContainer>
           <Web3Status />
         </Row>
       </StatusContainer>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,16 +1,15 @@
 // @ts-nocheck
 import { Trans } from '@lingui/macro';
-import { ReactNode, useCallback } from 'react';
-import { NavLinkProps, useLocation, useNavigate } from 'react-router-dom';
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
+import Logo from 'assets/jedi/logo.png';
+import MobileLogo from 'assets/jedi/squareLogo.png';
 import { useAccountDrawer } from 'components/AccountDrawer';
 import Web3Status from 'components/Web3Status';
 import { useIsPoolsPage } from 'hooks/useIsPoolsPage';
-import { Row } from 'nft/components/Flex';
-import Logo from 'assets/jedi/logo.png';
-import MobileLogo from 'assets/jedi/squareLogo.png';
-import { Nav, LogoContainer, NetworkNameContainer, MenuContainer, StatusContainer, MenuItem, ActiveMenuItem, ExternalMenuItem } from './styled';
 import { NetworkName } from './NetworkName';
+import { ActiveMenuItem, ExternalMenuItem, LogoContainer, MenuContainer, MenuItem, Nav, StatusContainer } from './styled';
 
 const MenuItemLink = ({ to, dataTestId, id, isActive, children }) => {
   const Component = isActive ? ActiveMenuItem : MenuItem;
@@ -75,12 +74,8 @@ const Navbar = () => {
       </MenuContainer>
 
       <StatusContainer>
-        <Row gap="16">
-          <NetworkNameContainer>
-            <NetworkName />
-          </NetworkNameContainer>
-          <Web3Status />
-        </Row>
+        <NetworkName />
+        <Web3Status />
       </StatusContainer>
     </Nav>
 

--- a/src/components/NavBar/styled.tsx
+++ b/src/components/NavBar/styled.tsx
@@ -31,7 +31,7 @@ export const LogoContainer = styled.div`
     display: none;
   }
 
-  @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.lg}px) {
     img.mobile {
       display: none;
     }
@@ -45,8 +45,10 @@ export const MenuContainer = styled.div`
   display: none;
   align-items: center;
   justify-content: space-around;
+  margin: 0px 12px;
   
   @media screen and (min-width: ${({ theme }) => theme.breakpoint.md}px) {
+    margin: 0px;
     display: flex;
   }
 `;
@@ -80,6 +82,10 @@ export const StatusContainer = styled(Box)`
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 8px;
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.lg}px) {
+    gap: 16px;
+  }
 `;
 
 export const MenuItem = styled(BaseMenuItem)``;
@@ -107,12 +113,4 @@ export const ActiveMenuItem = styled(BaseMenuItem)`
 
 export const ExternalMenuItem = styled.a`
   ${baseLinkCss};
-`;
-
-export const NetworkNameContainer = styled.div`
-  display: none;
-
-  @media screen and (min-width: ${({ theme }) => theme.breakpoint.lg}px) {
-    display: flex;
-  }
 `;

--- a/src/components/NavBar/styled.tsx
+++ b/src/components/NavBar/styled.tsx
@@ -108,3 +108,11 @@ export const ActiveMenuItem = styled(BaseMenuItem)`
 export const ExternalMenuItem = styled.a`
   ${baseLinkCss};
 `;
+
+export const NetworkNameContainer = styled.div`
+  display: none;
+
+  @media screen and (min-width: ${({ theme }) => theme.breakpoint.lg}px) {
+    display: flex;
+  }
+`;


### PR DESCRIPTION
Closes #51  

![Screenshot 2023-11-08 170542](https://github.com/jediswaplabs/JediSwapE2-interface/assets/3073099/9fa4d730-55ba-48b7-90d8-bcb1f03bb22b)

I used styled components. Is that correct?

Check out [src/components/NavBar/NetworkName.tsx:41](https://github.com/jediswaplabs/JediSwapE2-interface/compare/retroboy/swap-ui...add-network-name?expand=1#diff-96d881a7e10c9fb47b13fc5f2d9ff016053a6b8ece9cd64be92af48ff30bbeaeR41) if this is the correct behavior:
It hides the box if chainId or account is not shown. (compare [Figma](https://www.figma.com/file/UnuRGVIl2GLHyLSDGxajwp/JediSwap---Webapp-v2?node-id=1716%3A13338&mode=dev))